### PR TITLE
Allow setting alternative web service url with sonar.buildbreaker.alternative.server.url property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,4 @@ Gallio skipped will be marked "broken".
 | `sonar.buildbreaker.queryMaxAttempts` | The maximum number of queries to the API when waiting for report processing.  The build will break if this is reached.  Total wait time is `sonar.buildbreaker.queryMaxAttempts * sonar.buildbreaker.queryInterval`. | `30` | |
 | `sonar.buildbreaker.queryInterval` | The interval (ms) between queries to the API when waiting for report processing.  Total wait time is `sonar.buildbreaker.queryMaxAttempts * sonar.buildbreaker.queryInterval`. | `10000` | |
 | `sonar.buildbreaker.forbiddenConf` | Comma-separated list of `key=value` pairs that should break the build. | | `sonar.gallio.mode=skip` |
+| `sonar.buildbreaker.alternativeServerUrl` | URL to use for web service requests. If unset, uses the `serverUrl` property from `${sonar.working.directory}/report-task.txt`. | | |

--- a/src/main/java/org/sonar/plugins/buildbreaker/BuildBreakerPlugin.java
+++ b/src/main/java/org/sonar/plugins/buildbreaker/BuildBreakerPlugin.java
@@ -58,6 +58,12 @@ import java.util.List;
     name = "Forbidden configuration parameters",
     description = "Comma-separated list of <code>key=value</code> pairs that should break the build.",
     global = true,
+    project = false),
+  @Property(key = BuildBreakerPlugin.ALTERNATIVE_SERVER_URL_KEY,
+    name = "Alternative server URL",
+    description = "URL to use for web service requests. If unset, uses the <code>serverUrl</code> property from " +
+      "<code>${sonar.working.directory}/report-task.txt</code>.",
+    global = true,
     project = false)
 })
 public class BuildBreakerPlugin extends SonarPlugin {
@@ -74,6 +80,8 @@ public class BuildBreakerPlugin extends SonarPlugin {
   public static final String BUILD_BREAKER_LOG_STAMP = "[BUILD BREAKER] ";
 
   public static final String FORBIDDEN_CONF_KEY = "sonar.buildbreaker.forbiddenConf";
+
+  public static final String ALTERNATIVE_SERVER_URL_KEY = "sonar.buildbreaker.alternativeServerUrl";
 
   @Override
   public List getExtensions() {


### PR DESCRIPTION
Hey,

A possible solution to the issue I raised in https://github.com/SonarQubeCommunity/sonar-build-breaker/issues/16.

Let me know if that would be acceptable.
